### PR TITLE
Update Kovan network status link

### DIFF
--- a/components/index/netstats.jsx
+++ b/components/index/netstats.jsx
@@ -14,7 +14,7 @@ export default class Netstats extends Component {
           basic
           icon='bar chart'
           content='Open Netstats'
-          to='https://authorities.kovan.network'
+          to='https://kovan-stats.parity.io'
         />
         <br /><br />
         <p>View comprehensive realtime statistics about the state of the Kovan testnet on the authorities netstats page.</p>


### PR DESCRIPTION
Cant not access https://authorities.kovan.network to check network status. As the https://github.com/kovan-testnet/proposal said, update the network status link to: https://kovan-stats.parity.io/